### PR TITLE
Add other dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,9 +17,10 @@ dependencies:
     - unyt
     - py3dmol
     - scipy
-    - openbabel
+    - openbabel>=3.0.0
     - gsd
     - mdtraj
     - cmake
     - lammps
     - ocl-icd-system
+    - git-lfs


### PR DESCRIPTION
Per suggestion by @justinGilmer, I am adding `ocl-icd-system` as a dependency to `environment.yml` which help to avoid printing warnings.  I'm going to leave this open just in case we need to add anymore dependencies.