### PR TITLE
Change hyperref colors

### DIFF
--- a/supplementary_info/si_latest.pdf
+++ b/supplementary_info/si_latest.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e77bf2e57566e1eb9f8097042e864ef585521ef77d2aff0a9564f48b50f2f77a
-size 2716875
+oid sha256:e3129108ac6296b92fc3b90ccc878d842445bec1db6e5e5b4bd22965d18d43b0
+size 2716895

--- a/supplementary_info/si_latest.pdf
+++ b/supplementary_info/si_latest.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e77bf2e57566e1eb9f8097042e864ef585521ef77d2aff0a9564f48b50f2f77a
+size 2716875


### PR DESCRIPTION
Using hyperef changed the colors of the citations, changing back to black.